### PR TITLE
Use urllib3 for chunked requests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,8 @@ Release History
 
 **Improvements**
 
+- Requests now relies on urllib3 for performing chunked requests.
+
 **Bug Fixes**
 
 dev

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -511,7 +511,7 @@ class HTTPAdapter(BaseAdapter):
                 decode_content=False,
                 retries=self.max_retries,
                 timeout=timeout,
-                chunked=chunked
+                chunked=chunked,
             )
         except (ProtocolError, OSError) as err:
             raise ConnectionError(err, request=request)

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -500,65 +500,19 @@ class HTTPAdapter(BaseAdapter):
             timeout = TimeoutSauce(connect=timeout, read=timeout)
 
         try:
-            if not chunked:
-                resp = conn.urlopen(
-                    method=request.method,
-                    url=url,
-                    body=request.body,
-                    headers=request.headers,
-                    redirect=False,
-                    assert_same_host=False,
-                    preload_content=False,
-                    decode_content=False,
-                    retries=self.max_retries,
-                    timeout=timeout,
-                )
-
-            # Send the request.
-            else:
-                if hasattr(conn, "proxy_pool"):
-                    conn = conn.proxy_pool
-
-                low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
-
-                try:
-                    low_conn.putrequest(
-                        request.method, url, skip_accept_encoding=True
-                    )
-
-                    for header, value in request.headers.items():
-                        low_conn.putheader(header, value)
-
-                    low_conn.endheaders()
-
-                    for i in request.body:
-                        low_conn.send(hex(len(i))[2:].encode("utf-8"))
-                        low_conn.send(b"\r\n")
-                        low_conn.send(i)
-                        low_conn.send(b"\r\n")
-                    low_conn.send(b"0\r\n\r\n")
-
-                    # Receive the response from the server
-                    try:
-                        # For Python 2.7, use buffering of HTTP responses
-                        r = low_conn.getresponse(buffering=True)
-                    except TypeError:
-                        # For compatibility with Python 3.3+
-                        r = low_conn.getresponse()
-
-                    resp = HTTPResponse.from_httplib(
-                        r,
-                        pool=conn,
-                        connection=low_conn,
-                        preload_content=False,
-                        decode_content=False,
-                    )
-                except:
-                    # If we hit any problems here, clean up the connection.
-                    # Then, reraise so that we can handle the actual exception.
-                    low_conn.close()
-                    raise
-
+            resp = conn.urlopen(
+                method=request.method,
+                url=url,
+                body=request.body,
+                headers=request.headers,
+                redirect=False,
+                assert_same_host=False,
+                preload_content=False,
+                decode_content=False,
+                retries=self.max_retries,
+                timeout=timeout,
+                chunked=chunked
+            )
         except (ProtocolError, OSError) as err:
             raise ConnectionError(err, request=request)
 


### PR DESCRIPTION
This is a straight forward port of psf/requests#5128. The behavior is [very similar](https://github.com/urllib3/urllib3/blob/1.26.x/src/urllib3/connection.py#L236-L273) to Requests, the primary differences being it normalizes headers and it no longer sets the connection timeout to DEFAULT_POOL_TIMEOUT (`None`). I wrote up some tests but they're mostly testing for urllib3 behavior and didn't feel particularly useful. Happy to discuss if you have ideas though.

For the connection timeout, I looked over the [original PR](https://github.com/psf/requests/pull/2661) and it seems fine to drop. We're passing timeout to urllib3 correctly now and our hardcoded `None` has the same effect as the default in socket creation in Python 3.

For the headers, I think this may be problematic for the PreparedRequests flow since users will no longer have the option to control header casing. Urllib3 has typically taken a more hardline stance of what it emits since Seth took over which removes a lot of our controls. I'm personally alright with leaning into that, but I don't know if you have thoughts/concerns.