### PR TITLE
Remove simplejson

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@ Release History
 - Remove the ``__bool__`` and ``__nonzero__`` methods from a ``Response``
   object. This resolves issue #2002.
 
+- Remove conditional usage of `simplejson` module. Requests now solely relies
+  on the Python 3+ `json` module for encoding and decoding.
+
 **Improvements**
 
 - Requests now relies on urllib3 for performing chunked requests.

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -153,9 +153,7 @@ There's also a builtin JSON decoder, in case you're dealing with JSON data::
 
 In case the JSON decoding fails, ``r.json()`` raises an exception. For example, if
 the response gets a 204 (No Content), or if the response contains invalid JSON,
-attempting ``r.json()`` raises ``requests.exceptions.JSONDecodeError``. This wrapper exception
-provides interoperability for multiple exceptions that may be thrown by different
-python versions and json serialization libraries.
+attempting ``r.json()`` raises ``json.JSONDecodeError``.
 
 It should be noted that the success of the call to ``r.json()`` does **not**
 indicate the success of the response. Some servers may return a JSON object in a

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -161,7 +161,6 @@ from .exceptions import (
     FileModeWarning,
     ConnectTimeout,
     ReadTimeout,
-    JSONDecodeError,
 )
 
 # Set default logging handler to avoid "No handler found" warnings.

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -26,13 +26,6 @@ is_py2 = _ver[0] == 2
 #: Python 3.x?
 is_py3 = _ver[0] == 3
 
-has_simplejson = False
-try:
-    import simplejson as json
-
-    has_simplejson = True
-except ImportError:
-    import json
 
 # ---------
 # Specifics

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -58,7 +58,6 @@ if is_py2:
     basestring = basestring
     numeric_types = (int, long, float)
     integer_types = (int, long)
-    JSONDecodeError = ValueError
 
 elif is_py3:
     from urllib.parse import (
@@ -87,11 +86,6 @@ elif is_py3:
     # Keep OrderedDict for backwards compatibility.
     from collections import OrderedDict
     from collections.abc import Callable, Mapping, MutableMapping
-
-    if has_simplejson:
-        from simplejson import JSONDecodeError
-    else:
-        from json import JSONDecodeError
 
     builtin_str = str
     str = str

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -6,8 +6,6 @@ This module contains the set of Requests' exceptions.
 """
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
-from .compat import JSONDecodeError as CompatJSONDecodeError
-
 
 class RequestException(IOError):
     """There was an ambiguous exception that occurred while handling your
@@ -30,10 +28,6 @@ class RequestException(IOError):
 
 class InvalidJSONError(RequestException):
     """A JSON error occurred."""
-
-
-class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError):
-    """Couldn't decode the text into json."""
 
 
 class HTTPError(RequestException):

--- a/requests/models.py
+++ b/requests/models.py
@@ -6,6 +6,7 @@ This module contains the primary objects that power Requests.
 """
 import datetime
 import encodings.idna
+import json as complexjson
 import sys
 from io import UnsupportedOperation
 
@@ -27,7 +28,6 @@ from .compat import Callable
 from .compat import chardet
 from .compat import cookielib
 from .compat import is_py2
-from .compat import json as complexjson
 from .compat import JSONDecodeError
 from .compat import Mapping
 from .compat import str

--- a/requests/models.py
+++ b/requests/models.py
@@ -6,7 +6,7 @@ This module contains the primary objects that power Requests.
 """
 import datetime
 import encodings.idna
-import json as complexjson
+import json as json_
 import sys
 from io import UnsupportedOperation
 
@@ -28,7 +28,6 @@ from .compat import Callable
 from .compat import chardet
 from .compat import cookielib
 from .compat import is_py2
-from .compat import JSONDecodeError
 from .compat import Mapping
 from .compat import str
 from .compat import urlencode
@@ -43,7 +42,6 @@ from .exceptions import ContentDecodingError
 from .exceptions import HTTPError
 from .exceptions import InvalidJSONError
 from .exceptions import InvalidURL
-from .exceptions import JSONDecodeError as RequestsJSONDecodeError
 from .exceptions import MissingSchema
 from .exceptions import StreamConsumedError
 from .hooks import default_hooks
@@ -525,7 +523,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             content_type = "application/json"
 
             try:
-                body = complexjson.dumps(json, allow_nan=False)
+                body = json_.dumps(json, allow_nan=False)
             except ValueError as ve:
                 raise InvalidJSONError(ve, request=self)
 
@@ -949,7 +947,7 @@ class Response:
         r"""Returns the json-encoded content of a response, if any.
 
         :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
-        :raises requests.exceptions.JSONDecodeError: If the response body does not
+        :raises json.JSONDecodeError: If the response body does not
             contain valid json.
         """
 
@@ -961,9 +959,7 @@ class Response:
             encoding = guess_json_utf(self.content)
             if encoding is not None:
                 try:
-                    return complexjson.loads(
-                        self.content.decode(encoding), **kwargs
-                    )
+                    return json_.loads(self.content.decode(encoding), **kwargs)
                 except UnicodeDecodeError:
                     # Wrong UTF codec detected; usually because it's not UTF-8
                     # but some other 8-bit codec.  This is an RFC violation,
@@ -971,15 +967,7 @@ class Response:
                     # used.
                     pass
 
-        try:
-            return complexjson.loads(self.text, **kwargs)
-        except JSONDecodeError as e:
-            # Catch JSON-related errors and raise as requests.JSONDecodeError
-            # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
-            if is_py2:  # e is a ValueError
-                raise RequestsJSONDecodeError(e.message)
-            else:
-                raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
+        return json_.loads(self.text, **kwargs)
 
     @property
     def links(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2752,8 +2752,3 @@ class TestPreparingURLs:
         data = {"foo": float("nan")}
         with pytest.raises(requests.exceptions.InvalidJSONError):
             r = requests.post(httpbin("post"), json=data)
-
-    def test_json_decode_compatibility(self, httpbin):
-        r = requests.get(httpbin("bytes/20"))
-        with pytest.raises(requests.exceptions.JSONDecodeError):
-            r.json()


### PR DESCRIPTION
This is a straight port of the original 3.0.0 PR and removal of the recent changes we made to exception handling. I figured it would be best to have clean handling instead of bringing the exception shim forward with no purpose.